### PR TITLE
Correct input shape for produce calls

### DIFF
--- a/examples/glrm.py
+++ b/examples/glrm.py
@@ -6,5 +6,5 @@ A = np.array([[1, 2, 3, 4], [2, 4, 6, 8], [4, 5, 6, 7]])
 g = glrm(n_components=2) #create a class for GLRM (Here it does PCA)
 g.set_training_data(inputs=A)
 g.fit()
-a_new = np.array([6, 7, 8, 9]) #initialize a new row to be tested
+a_new = np.array([[6, 7, 8, 9]]) #initialize a new row to be tested
 x = g.produce(inputs=a_new) #get the latent representation of a_new

--- a/examples/nnmf.py
+++ b/examples/nnmf.py
@@ -6,5 +6,5 @@ A = np.array([[1, 2, 3, 4], [2, 4, 6, 8], [4, 5, 6, 7]])
 g = nnmf(n_components=2) #create a class for nonnegative matrix factorization
 g.set_training_data(inputs=A)
 g.fit()
-a_new = np.array([6, 7, 8, 9]) #initialize a new row to be tested
+a_new = np.array([[6, 7, 8, 9]]) #initialize a new row to be tested
 x = g.produce(inputs=a_new) #get the latent representation of a_new

--- a/examples/pca.py
+++ b/examples/pca.py
@@ -6,5 +6,5 @@ A = np.array([[1, 2, 3, 4], [2, 4, 6, 8], [4, 5, 6, 7]])
 g = pca(n_components=2) #create a class for PCA
 g.set_training_data(inputs=A)
 g.fit()
-a_new = np.array([6, 7, 8, 9]) #initialize a new row to be tested
+a_new = np.array([[6, 7, 8, 9]]) #initialize a new row to be tested
 x = g.produce(inputs=a_new) #get the latent representation of a_new

--- a/examples/rpca.py
+++ b/examples/rpca.py
@@ -6,5 +6,5 @@ A = np.array([[1, 2, 3, 4], [2, 4, 6, 8], [4, 5, 6, 7]])
 g = rpca(n_components=2) #create a class for robust PCA
 g.set_training_data(inputs=A)
 g.fit()
-a_new = np.array([6, 7, 8, 9]) #initialize a new row to be tested
+a_new = np.array([[6, 7, 8, 9]]) #initialize a new row to be tested
 x = g.produce(inputs=a_new) #get the latent representation of a_new


### PR DESCRIPTION
The `produce` method requires input shape to match training input shape, so this updates the examples accordingly.